### PR TITLE
Increase gunicorn timeout to 60s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ USER app
 
 ENV ELASTIC_CLIENT_APIVERSIONING=1
 
-CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:8888", "serve:app"]
+CMD ["gunicorn", "-w", "4", "-t", "60", "-b", "0.0.0.0:8888", "serve:app"]


### PR DESCRIPTION
Since new pages are scraped synchronously in the POST request which adds them, adding a collection of several pages can time out.  So, make the timeout bigger, rather than take on the significantly more complex task of asynchronous scraping.